### PR TITLE
Only update dbhost is MySQL variable set

### DIFF
--- a/rc.local
+++ b/rc.local
@@ -1,3 +1,5 @@
 #!/bin/sh
-sed -i "s/.*dbhost.*/  'dbhost' => '$MYSQL_PORT_3306_TCP_ADDR',/" /var/www/owncloud/config/config.php
+if [ ! -z "$MYSQL_PORT_3306_TCP_ADDR" ]; then
+	sed -i "s/.*dbhost.*/  'dbhost' => '$MYSQL_PORT_3306_TCP_ADDR',/" /var/www/owncloud/config/config.php
+fi
 service apache2 start


### PR DESCRIPTION
I didn't realize that I had included my MySQL trick in the pull request, if you're going to have it in your repo it should probably be wrapped with a test case. This way it will be ignored if they are not connecting the container to an external MySQL host. That was my fault on the previous pull request, I only meant to submit the 8.0.4 change.  